### PR TITLE
Writes must be UINT32

### DIFF
--- a/pyexr/exr.py
+++ b/pyexr/exr.py
@@ -22,7 +22,7 @@ PXR24_COMPRESSION = Imath.Compression(Imath.Compression.PXR24_COMPRESSION)
 NP_PRECISION = {
   "FLOAT": np.float32,
   "HALF":  np.float16,
-  "UINT":  np.uint8
+  "UINT":  np.uint32
 }
 
 


### PR DESCRIPTION
OpenEXR expects 4-byte integers on write