### PR TITLE
Replace fromstring() with frombuffer() to fix a DeprecationWarning

### DIFF
--- a/pyexr/exr.py
+++ b/pyexr/exr.py
@@ -197,7 +197,7 @@ class InputFile(object):
     matrix = np.zeros((self.height, self.width, len(channels)), dtype=NP_PRECISION[str(precision)])
     for i, string in enumerate(strings):
       precision = NP_PRECISION[str(self.channel_precision[channels[i]])]
-      matrix[:,:,i] = np.fromstring(string, dtype = precision) \
+      matrix[:,:,i] = np.frombuffer(string, dtype = precision) \
                         .reshape(self.height, self.width)
     return matrix
 


### PR DESCRIPTION
I only tested this with a couple of images, but it appears that frombuffer() is a drop-in replacement to fromstring() in this case.

This fixes issue #11.