### PR TITLE
Add close() method and with statement support to InputFile

### DIFF
--- a/pyexr/exr.py
+++ b/pyexr/exr.py
@@ -246,6 +246,15 @@ class InputFile(object):
             .reshape(self.height, self.width)
     return return_dict
 
+  def __enter__(self):
+    return self
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    self.close()
+
+  def close(self):
+    self.input_file.close()
+
 
 def _sort_dictionary(key):
   if key == 'R' or key == 'r':


### PR DESCRIPTION
Fixing two minor annoyances with the library :)

(1) The addition of the close() method allows to programmatically close an open .exr without waiting until the program completion. I often find myself being prevented to operate on files because of dangling, open file descriptors.

(2) The "with" statement support allows to write such as:
```
with pyexr.open(filepath) as exr_image:
    print(exr_image.get_all().keys())
```
which closes the open file whatever happens (e.g. should an exception happen).